### PR TITLE
WIP: Use transaction

### DIFF
--- a/lambda/postMessage/postMessage.py
+++ b/lambda/postMessage/postMessage.py
@@ -51,7 +51,7 @@ def add_message(event):
             'user.type': payload['user']['type'],
             'effect': json.dumps(payload['effect'])
         },
-        ConditionExpression=Attr('game').not_exists(),
+        ConditionExpression="attribute_not_exists(game)",
         ClientRequestToken=payload['id']
     )
     
@@ -69,7 +69,7 @@ def transact_put_item(Item, ConditionExpression, ClientRequestToken):
                         "user.type": {"S": Item['user.type']},
                         "effect": {"S": Item['effect']}
                     },
-                    "ConditionExpression": "attribute_not_exists(game)"
+                    "ConditionExpression": ConditionExpression
                 }
             }
         ],

--- a/lambda/postMessage/postMessage.py
+++ b/lambda/postMessage/postMessage.py
@@ -10,6 +10,7 @@ logger.setLevel("INFO")
 
 dynamodb = boto3.resource('dynamodb')
 table = dynamodb.Table('merlin_messages')
+client = boto3.client('dynamodb')
 
 def lambda_handler(event, context):
     logger.info(event)
@@ -41,7 +42,7 @@ def add_message(event):
     else:
         seq = 0
 
-    table.put_item(
+    transact_put_item(
         Item={
             'game': event['game'],
             'seq': seq,
@@ -50,7 +51,29 @@ def add_message(event):
             'user.type': payload['user']['type'],
             'effect': json.dumps(payload['effect'])
         },
-        ConditionExpression=Attr('game').not_exists()
+        ConditionExpression=Attr('game').not_exists(),
+        ClientRequestToken=payload['id']
+    )
+    
+def transact_put_item(Item, ConditionExpression, ClientRequestToken):
+    client.transact_write_items(
+        TransactItems=[
+            {
+                'Put': {
+                    "TableName": "merlin_messages",
+                    "Item": {
+                        "game": {"S": Item['game']},
+                        "seq": {"N": str(Item['seq'])},  # Assuming seq is a number
+                        "id": {"S": Item['id']},
+                        "user.id": {"N": str(Item['user.id'])},
+                        "user.type": {"S": Item['user.type']},
+                        "effect": {"S": Item['effect']}
+                    },
+                    "ConditionExpression": "attribute_not_exists(game)"
+                }
+            }
+        ],
+        ClientRequestToken=ClientRequestToken
     )
     
 def retry_exc(exc):


### PR DESCRIPTION
Try out using a transaction to ensure idempotence. This didn't work. If we have to retry the transaction because the condition check failed, it still has registered the transaction as having happened for idempotence. We get the error

{"errorMessage": "An error occurred (IdempotentParameterMismatchException) when calling the TransactWriteItems operation: Specified idempotent token was used with different request parameters within the idempotency window", "errorType": "IdempotentParameterMismatchException", "requestId": "80221e0b-bc42-45b7-ad60-5ec3725de503", ...}

because we're trying to retry the transaction with a different sequence number.